### PR TITLE
Add publishConfig for scoped packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "storybook": {
     "displayName": "Addon Kit",
     "supportedFrameworks": [


### PR DESCRIPTION
If somebody tries to publish a scoped package, e.g. `@storybook/addon-svelte-csf` they will hit this with the current publishing instructions