### PR TITLE
fix: decorator types

### DIFF
--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -1,7 +1,7 @@
-import { StoryFn as StoryFunction, StoryContext } from "@storybook/addons";
+import type { DecoratorFunction } from "@storybook/addons";
 import { useEffect, useGlobals } from "@storybook/addons";
 
-export const withGlobals = (StoryFn: StoryFunction, context: StoryContext) => {
+export const withGlobals: DecoratorFunction = (StoryFn, context) => {
   const [{ myAddon }] = useGlobals();
   // Is the addon being used in the docs panel
   const isInDocs = context.viewMode === "docs";

--- a/src/withRoundTrip.ts
+++ b/src/withRoundTrip.ts
@@ -1,8 +1,9 @@
-import { StoryFn as StoryFunction, useChannel } from "@storybook/addons";
+import { useChannel } from "@storybook/addons";
+import type { DecoratorFunction } from "@storybook/addons";
 import { STORY_CHANGED } from "@storybook/core-events";
 import { EVENTS } from "./constants";
 
-export const withRoundTrip = (storyFn: StoryFunction) => {
+export const withRoundTrip: DecoratorFunction = (storyFn) => {
   const emit = useChannel({
     [EVENTS.REQUEST]: () => {
       emit(EVENTS.RESULT, {


### PR DESCRIPTION
When starting a fresh new project and running `yarn build` we got the following TS errors:
![Screenshot 2022-04-03 at 18 39 36](https://user-images.githubusercontent.com/45885054/161438442-637b21b6-0ce7-4a3b-8a3a-b2e58795c370.png)

In this PR I changed the decorators to use the `DecoratorFunction` type so the story and context types are inferred automatically.
