### PR TITLE
Fix initial type of addon keywords

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -60,7 +60,7 @@ const questions = [
   {
     type: "list",
     name: "keywords",
-    initial: ["storybook-addons"],
+    initial: "storybook-addons",
     message: "Enter addon keywords (comma separated)",
     separator: ",",
     format: (keywords) =>


### PR DESCRIPTION
In the initial setup with `yarn` command, an error will occur if keywords are not entered (left as default values).

```sh
✔ Enter addon keywords (comma separated) … storybook-addons
/path/to/storybook-addon-something/node_modules/prompts/lib/prompts.js:123
    onSubmit: str => str.split(sep).map(s => s.trim())
                         ^

TypeError: str.split is not a function
    at onSubmit (/path/to/storybook-addon-something/node_modules/prompts/lib/prompts.js:123:26)
```

Looking at [the source code of prompts](https://github.com/terkelg/prompts/blob/master/lib/prompts.js#L112), I thought the initial value of keywords should be a string type.

