### PR TITLE
Add addon-generated toolbar example

### DIFF
--- a/src/preset/preview.ts
+++ b/src/preset/preview.ts
@@ -12,3 +12,20 @@ import { withGlobals } from "../withGlobals";
 import { withRoundTrip } from "../withRoundTrip";
 
 export const decorators = [withGlobals, withRoundTrip];
+
+export const globalTypes = {
+  theme: {
+    name: "Theme",
+    description: "Global theme for components",
+    toolbar: {
+      icon: "circlehollow",
+      title: "Theme",
+      items: [
+        { value: "light", icon: "circlehollow", title: "light" },
+        { value: "dark", icon: "circle", title: "dark" },
+        { value: "side-by-side", icon: "sidebar", title: "side by side" },
+        { value: "stacked", icon: "bottombar", title: "stacked" },
+      ],
+    },
+  },
+};

--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -5,6 +5,7 @@ export const withGlobals: DecoratorFunction = (StoryFn, context) => {
   const [{ myAddon }] = useGlobals();
   // Is the addon being used in the docs panel
   const isInDocs = context.viewMode === "docs";
+  const { theme } = context.globals;
 
   useEffect(() => {
     // Execute your side effect here
@@ -16,8 +17,9 @@ export const withGlobals: DecoratorFunction = (StoryFn, context) => {
     displayToolState(selectorId, {
       myAddon,
       isInDocs,
+      theme,
     });
-  }, [myAddon]);
+  }, [myAddon, theme]);
 
   return StoryFn();
 };
@@ -37,7 +39,7 @@ function displayToolState(selector: string, state: any) {
   }
 
   preElement.innerText = `This snippet is injected by the withGlobals decorator.
-It updates as the user interacts with the ⚡ tool in the toolbar above.
+It updates as the user interacts with the ⚡ or Theme tools in the toolbar above.
 
 ${JSON.stringify(state, null, 2)}
 `;


### PR DESCRIPTION
Not sure this is the best example, but proposing this to illustrate that instead of implementing its own toolbar functionality, an addon can reuse the functionality provided by `addon-toolbars` if it's installed -- either directly or via `addon-essentials`.

The benefits of this are:
1. The addon author doesn't have to write any UI
2. Improvements to the toolbar addon will be picked up "for free"

The costs are:
1. It's less flexible than defining your own UI
2. I'm not sure whether SB can make any guarantees about toolbar order currently

@winkerVSbecks feel free to reject or modify as you find appropriate!