### PR TITLE
Chore: Fixes to broken links

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -21,10 +21,6 @@ export const Tool = () => {
       title="Enable my addon"
       onClick={toggleMyTool}
     >
-      {/*
-        Checkout https://next--storybookjs.netlify.app/official-storybook/?path=/story/basics-icon--labels
-        for the full list of icons
-      */}
       <Icons icon="lightning" />
     </IconButton>
   );

--- a/src/components/PanelContent.tsx
+++ b/src/components/PanelContent.tsx
@@ -19,7 +19,7 @@ interface PanelContentProps {
 }
 
 /**
- * Checkout https://github.com/storybookjs/storybook/blob/next/addons/jest/src/components/Panel.tsx
+ * Checkout https://github.com/storybookjs/storybook/blob/next/code/addons/jest/src/components/Panel.tsx
  * for a real world example
  */
 export const PanelContent: React.FC<PanelContentProps> = ({


### PR DESCRIPTION
With this pull request the reference to the official Storybook hosted in Netlify is removed as it's no longer active. As per the following [issue](https://github.com/storybookjs/storybook/issues/19436) and [pull request](https://github.com/storybookjs/storybook/pull/19343). Also featured here is an update to one of the links to the monorepo, as it's no longer valid as part of the internal restructure performed by Norbert.


@winkerVSbecks, when you have a chance, take a look and let me know if you have any additional feedback on this.

Thanks in advance.