### PR TITLE
fix: `postinstall` script removal

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -141,7 +141,7 @@ const main = async () => {
     .replace(REPLACE_TEMPLATES.repoUrl, repoUrl)
     .replace(REPLACE_TEMPLATES.displayName, displayName)
     .replace(REPLACE_TEMPLATES.supportedFrameworks, supportedFrameworks)
-    .replace('    "postinstall": "node scripts/welcome.js",\n', "");
+    .replace(/\s*"postinstall".*node.*scripts\/welcome.js.*",/, '');
 
   fs.writeFileSync(packageJson, packageJsonContents);
 


### PR DESCRIPTION
replace `postinstall` script removal hardcoded string with regular expression because it was not being removed correctly from package.json.