### PR TITLE
Remove old HMR code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,2 @@
-if (module && module.hot && module.hot.decline) {
-  module.hot.decline();
-}
-
 // make it work with --isolatedModules
 export default {};


### PR DESCRIPTION
This may have helped in development (?) but isn't good to ship in production code, due to different environments that don't define `module` (namely ESM)