### PR TITLE
fix: published addon is not registered

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "node": "./dist/index.js",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
@@ -27,11 +26,6 @@
       "require": "./dist/preview.js",
       "import": "./dist/preview.mjs",
       "types": "./dist/preview.d.ts"
-    },
-    "./register": {
-      "require": "./dist/manager.js",
-      "import": "./dist/manager.mjs",
-      "types": "./dist/manager.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -13,19 +13,25 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "node": "./dist/index.js",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./manager.js": {
+    "./manager": {
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",
       "types": "./dist/manager.d.ts"
     },
-    "./preview.js": {
+    "./preview": {
       "require": "./dist/preview.js",
       "import": "./dist/preview.mjs",
       "types": "./dist/preview.d.ts"
+    },
+    "./register": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
I had the issue that my addon was working locally with local-preset.js but the published version was not registered and did not show.

I'm not 100 % sure this is the best fix but I just copy pasted the package.json export field of the official storybook addons and it worked. https://github.com/storybookjs/storybook/blob/a66c4db8f6fee28b658f497cae8ddafc26625e94/code/addons/measure/package.json#L27-L50


