### PR TITLE
refactor(deps): add @types/react to satisfy pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@storybook/react-vite": "^7.0.0",
     "@storybook/testing-library": "^0.0.14-next.1",
     "@types/node": "^18.15.0",
+    "@types/react": "^18.0.34",
     "@vitejs/plugin-react": "^3.1.0",
     "auto": "^10.3.0",
     "boxen": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,15 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@^18.0.34":
+  version "18.0.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.34.tgz#e553444a578f023e6e1ac499514688fb80b0a984"
+  integrity sha512-NO1UO8941541CJl1BeOXi8a9dNKFK09Gnru5ZJqkm4Q3/WoQJtHvmwt0VX0SB9YCEwe7TfSSxDuaNmx6H2BAIQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"


### PR DESCRIPTION
This PR add `@types/react` devDependency. This is needed for users who install dependencies with **pnpm**. In such case, tsc complains about missing React types, though **yarn** and **npm** work ok without it.