### PR TITLE
Fix addons not working when resolved with `getAbsolutePath`

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1,0 +1,1 @@
+import './dist/manager';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storybook-addon-kit",
+  "name": "storybook-addon-kit-test-module",
   "version": "0.0.0",
   "description": "everything you need to build a Storybook addon",
   "keywords": [

--- a/preset.js
+++ b/preset.js
@@ -1,0 +1,4 @@
+// this file is slightly misleading. It needs to be CJS, and thus in this "type": "module" package it should be named preset.cjs
+// but Storybook won't pick that filename up so we have to name it preset.js instead
+
+module.exports = require('./dist/preset.cjs');

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,1 @@
+export * from './dist/preview';


### PR DESCRIPTION
Follow-up to #63

In certain monorepo and/or Yarn PnP situations, users will resolve their addon packages with an absolute path instead of the package name, eg.:

```ts
// .storybook/main.js
import { join, dirname } from "path";

function getAbsolutePath(value) {
  return dirname(require.resolve(join(value, "package.json")));
}

const config = {
  ...,
  addons: [
    getAbsolutePath("storybook-addon-kit-test-module"),
  ],
  ...
}
```

In that situation, Node.js will ignore the package's export maps when resolving it and thus none of the entries will be found. To get around that we have to have `preset.js`, `manager.js` and/or `preview.js` files in the root package because they _will_ be used instead.

This has always been the case, we just missed this scenario in #63 and removed the files by mistake.