### PR TITLE
Replace ts-dedent with dedent in welcome script

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,7 +1,7 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable no-console */
 import prompts from 'prompts';
-import { dedent } from 'ts-dedent';
+import dedent from 'dedent';
 import { dirname, resolve } from 'path';
 import { readFile, writeFile } from 'fs/promises';
 import { execSync } from 'child_process';


### PR DESCRIPTION
Hey 👋 

- The addon-kit template uses npm by default, but users might want to switch to another package manager like pnpm.

- The welcome script [uses `ts-dedent`](https://github.com/storybookjs/addon-kit/blob/main/scripts/welcome.js#L4) which is not declared as an explicit (_dev_)Dependency, [while `dedent` is](https://github.com/storybookjs/addon-kit/blob/main/package.json#L65).
- `ts-dedent` is used, but `dedent` isn't.

It works out of the box when sticking to npm because `ts-dedent` is hoisted from other dependencies. However, with package managers that do not hoist dependencies (e.g. pnpm), `ts-dedent`  is not resolvable unless it is shamefully hoisted. 

I do think fixing this (_even though the template is based on npm_) is a very simple QoL improvement with no extra costs! 

Now there are two ways, either : 
1. replace `dedent` with `ts-dedent` in `devDependencies`.
2. replace `ts-dedent` with `dedent` in `scripts/welcome.js`

I went for that second option (mostly because of package sizes and it didn't require any change to dependencies)